### PR TITLE
Add logout

### DIFF
--- a/backend/app/controllers/api/v1/sessions_controller.rb
+++ b/backend/app/controllers/api/v1/sessions_controller.rb
@@ -1,0 +1,31 @@
+module Api
+  module V1
+    class SessionsController < BaseController
+      def destroy
+        # Con Denylist, Devise se encargará de revocar el token automáticamente
+        # Solo hay que asegurarse de enviar el token en la solicitud
+
+        if current_user
+          # Revoca el token actual
+          token = extract_jwt_token
+          JwtDenylist.create!(jti: token, exp: Time.now + 2.days)
+
+          render json: { message: "Sesión cerrada correctamente" }, status: :ok
+        else
+          render json: { message: "No hay sesión activa" }, status: :unauthorized
+        end
+      end
+
+      private
+
+      # Este método debería estar disponible a través de JwtAuthenticable
+      # Si no, agregarlo aquí
+      def extract_jwt_token
+        auth_header = request.headers["Authorization"]
+        return auth_header.split(" ").last if auth_header.present? && auth_header.start_with?("Bearer ")
+
+        request.headers["X-JWT-Token"]
+      end
+    end
+  end
+end

--- a/backend/app/models/jwt_denylist.rb
+++ b/backend/app/models/jwt_denylist.rb
@@ -1,0 +1,5 @@
+class JwtDenylist < ApplicationRecord
+  include Devise::JWT::RevocationStrategies::Denylist
+
+  self.table_name = "jwt_denylist"
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :jwt_authenticatable, jwt_revocation_strategy: Devise::JWT::RevocationStrategies::Null
+  devise :jwt_authenticatable, jwt_revocation_strategy: Devise::JWT::RevocationStrategies::Denylist
 
   has_many :magic_link_tokens, dependent: :destroy
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
       resources :departments, only: [ :index ]
       resources :companies, only: [ :index, :create, :show, :update ]
       resources :check_feature, only: [ :index ]
+      delete "/logout", to: "sessions#destroy"
     end
   end
 

--- a/backend/db/migrate/20250420235019_create_jwt_denylist.rb
+++ b/backend/db/migrate/20250420235019_create_jwt_denylist.rb
@@ -1,0 +1,10 @@
+class CreateJwtDenylist < ActiveRecord::Migration[8.0]
+  def change
+    create_table :jwt_denylist do |t|
+      t.string :jti, null: false
+      t.datetime :exp, null: false
+    end
+
+    add_index :jwt_denylist, :jti
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_20_143757) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_20_235019) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -66,6 +66,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_20_143757) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["code"], name: "index_features_on_code", unique: true
+  end
+
+  create_table "jwt_denylist", force: :cascade do |t|
+    t.string "jti", null: false
+    t.datetime "exp", null: false
+    t.index ["jti"], name: "index_jwt_denylist_on_jti"
   end
 
   create_table "magic_link_tokens", force: :cascade do |t|

--- a/frontend/src/components/navbar/index.tsx
+++ b/frontend/src/components/navbar/index.tsx
@@ -2,11 +2,19 @@ import Button from '../ui/button';
 import { NavbarProps } from './types';
 import {SignOutIcon} from '@primer/octicons-react'
 import { Link } from 'react-router-dom';
+import { useLogout } from '../../hooks/use-logout';
+import Loading from '../loading';
 
 const Navbar = ({ title }: NavbarProps) => {
+  const { logout, isLoading: isLogoutLoading } = useLogout();
+
   const handleLogout = () => {
-    alert('va a cerrar session');
+    logout();
   };
+
+  if (isLogoutLoading) {
+    return <Loading />;
+  }
 
   return (
     <nav className="flex justify-between items-center px-5 md:px-20 h-12 bg-white shadow">
@@ -23,6 +31,7 @@ const Navbar = ({ title }: NavbarProps) => {
         variant="primary" 
         onClick={handleLogout}
         className="w-auto"
+        disabled={isLogoutLoading}
       />
     </nav>
   );

--- a/frontend/src/contexts/auth-context/context.tsx
+++ b/frontend/src/contexts/auth-context/context.tsx
@@ -11,4 +11,5 @@ const initialState: AuthState = {
 export const AuthContext = createContext<AuthContextParams>({
   state: initialState,
   authenticate: () => {},
+  removeJwt: () => {},
 }); 

--- a/frontend/src/contexts/auth-context/index.tsx
+++ b/frontend/src/contexts/auth-context/index.tsx
@@ -79,9 +79,19 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     });
   };
 
+  const removeJwt = () => {
+    sessionStorage.removeItem('jwt');
+
+    setState({
+      ...initialState,
+      data: null
+    });
+  };
+
   const value: AuthContextParams = {
     state,
     authenticate,
+    removeJwt
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/contexts/auth-context/types.ts
+++ b/frontend/src/contexts/auth-context/types.ts
@@ -27,4 +27,5 @@ export interface AuthState {
 export interface AuthContextParams {
   state: AuthState;
   authenticate: (params: UseAuthenticateTokenParams) => void;
+  removeJwt: () => void;
 }

--- a/frontend/src/hooks/use-logout/index.ts
+++ b/frontend/src/hooks/use-logout/index.ts
@@ -1,0 +1,47 @@
+import { useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useApi } from '../use-api';
+import { AuthContext } from '../../contexts/auth-context';
+import { FlashContext } from '../../contexts/flash-context';
+import { UseLogoutReturn } from './types';
+
+export const useLogout = (): UseLogoutReturn => {
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const { fetchData } = useApi();
+  const navigate = useNavigate();
+  const { removeJwt } = useContext(AuthContext);
+  const { setFlash } = useContext(FlashContext);
+  const [ isLogout, setIsLogout ] = useState<boolean>(false);
+
+  const logout = async (): Promise<void> => {
+    setIsLoading(true);
+
+    try {
+      // Llamar al endpoint de logout en el backend
+      await fetchData('/api/v1/logout', { method: 'DELETE' });
+
+      removeJwt();
+      setFlash('Sesión cerrada correctamente', 'success');
+      
+      // Redirigir al usuario a la página de login
+      setIsLogout(true);
+      navigate('/login');
+    } catch (error) {
+      console.error('Error al cerrar sesión:', error);
+      setFlash('Error al cerrar sesión', 'error');
+      
+      // En caso de error, intentar hacer logout localmente de todas formas
+      removeJwt();
+      setIsLogout(true);
+      navigate('/login');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    isLoading,
+    logout,
+    isLogout
+  };
+}; 

--- a/frontend/src/hooks/use-logout/types.ts
+++ b/frontend/src/hooks/use-logout/types.ts
@@ -1,0 +1,5 @@
+export interface UseLogoutReturn {
+  isLoading: boolean;
+  logout: () => Promise<void>;
+  isLogout: boolean;
+}


### PR DESCRIPTION
Added deny list strategy for token revocation.

When a user logs in, a token is stored in session storage:
<img width="1915" alt="image" src="https://github.com/user-attachments/assets/03a98b09-57ce-429c-8f60-f0afa2a21a13" />
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/abafdcdd-c93c-4b11-954d-ecd8eb71eabd" />

On logout, the frontend calls a specific endpoint. In the backend, the token is registered in a deny list table, and the frontend clears session storage:
<img width="1195" alt="image" src="https://github.com/user-attachments/assets/b512725b-035e-46a6-b796-8722ebf74ddd" />

